### PR TITLE
Refactor add ceo

### DIFF
--- a/Boardly.Dominio/Puertos/Servicios/IObtenerCeoId.cs
+++ b/Boardly.Dominio/Puertos/Servicios/IObtenerCeoId.cs
@@ -1,0 +1,6 @@
+namespace Boardly.Dominio.Puertos.Servicios;
+
+public interface IObtenerCeoId
+{
+    Task<Guid?> ObtenerCeoIdAsync(Guid usuarioId,CancellationToken cancellationToken);
+}

--- a/Boardly.Dominio/Puertos/Servicios/IObtenerEmpleadoId.cs
+++ b/Boardly.Dominio/Puertos/Servicios/IObtenerEmpleadoId.cs
@@ -1,0 +1,6 @@
+namespace Boardly.Dominio.Puertos.Servicios;
+
+public interface IObtenerEmpleadoId
+{
+    Task<Guid?> ObtenerEmpleadoIdAsync(Guid usuarioId, CancellationToken cancellationToken);
+}

--- a/Boardly.Infraestructura.Persistencia/Adaptadores/Servicios/ObtenerCeoId.cs
+++ b/Boardly.Infraestructura.Persistencia/Adaptadores/Servicios/ObtenerCeoId.cs
@@ -1,0 +1,18 @@
+using Boardly.Dominio.Modelos;
+using Boardly.Dominio.Puertos.Servicios;
+using Boardly.Infraestructura.Persistencia.Contexto;
+using Microsoft.EntityFrameworkCore;
+
+namespace Boardly.Infraestructura.Persistencia.Adaptadores.Servicios;
+
+public class ObtenerCeoId(BoardlyContexto boardlyContexto) : IObtenerCeoId
+{
+    public async Task<Guid?> ObtenerCeoIdAsync(Guid usuarioId, CancellationToken cancellationToken)
+    {
+        var ceo = await boardlyContexto.Set<Ceo>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.UsuarioId == usuarioId, cancellationToken);
+        
+        return ceo!.CeoId;
+    }
+}

--- a/Boardly.Infraestructura.Persistencia/Adaptadores/Servicios/ObtenerEmpleadoId.cs
+++ b/Boardly.Infraestructura.Persistencia/Adaptadores/Servicios/ObtenerEmpleadoId.cs
@@ -1,0 +1,18 @@
+using Boardly.Dominio.Modelos;
+using Boardly.Dominio.Puertos.Servicios;
+using Boardly.Infraestructura.Persistencia.Contexto;
+using Microsoft.EntityFrameworkCore;
+
+namespace Boardly.Infraestructura.Persistencia.Adaptadores.Servicios;
+
+public class ObtenerEmpleadoId(BoardlyContexto boardlyContexto) : IObtenerEmpleadoId
+{
+    public async Task<Guid?> ObtenerEmpleadoIdAsync(Guid usuarioId, CancellationToken cancellationToken)
+    {
+        var empleado = await boardlyContexto.Set<Empleado>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.UsuarioId == usuarioId, cancellationToken);
+
+        return empleado?.EmpleadoId;
+    }
+}

--- a/Boardly.Infraestructura.Persistencia/InyeccionDeDependencia.cs
+++ b/Boardly.Infraestructura.Persistencia/InyeccionDeDependencia.cs
@@ -50,8 +50,10 @@ public static class InyeccionDeDependencia
             servicio.AddTransient<IProyectoRepositorio,ProyectoRepositorio>();
             servicio.AddTransient<ITareaRepositorio, TareaRepositorio>();
             servicio.AddScoped<IObtenerRoles, ObtenerRoles>();
-            
-        #endregion
+            servicio.AddScoped<IObtenerCeoId, ObtenerCeoId>();
+            servicio.AddScoped<IObtenerEmpleadoId, ObtenerEmpleadoId>();
+
+            #endregion
 
     }
     


### PR DESCRIPTION
# Add CEO and Employee ID Retrieval Services

## Summary

This PR introduces new services to retrieve the CEO and Employee IDs based on the current user's ID. These methods are part of the user role logic and can be used to inject role-specific identifiers into JWT claims or other authorization contexts.

---

## Changes

- Added `ObtenerCeoIdAsync(Guid usuarioId, CancellationToken)` to fetch CEO ID.
- Added `ObtenerEmpleadoIdAsync(Guid usuarioId, CancellationToken)` to fetch Employee ID.
- Refactored token generation to optionally include CEO and Employee IDs as custom JWT claims.
- Ensured `AsNoTracking()` queries for performance and immutability.

---

## Motivation

These changes are part of the authentication layer enhancement. By including CEO and Employee IDs at the time of login/token generation, we enable better authorization handling and reduce the need for future role lookups in protected endpoints.
